### PR TITLE
Change deprecated 'codeaurora.org' source URIs to github

### DIFF
--- a/meta-bsp/recipes-bsp/imx-atf/imx-atf_2.4.bb
+++ b/meta-bsp/recipes-bsp/imx-atf/imx-atf_2.4.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://${COREBASE}/meta/files/common-licenses/BSD-3-Clause;m
 PV .= "+git${SRCPV}"
 
 SRCBRANCH = "lf_v2.4"
-ATF_SRC ?= "git://source.codeaurora.org/external/imx/imx-atf.git;protocol=https"
+ATF_SRC ?= "git://github.com/nxp-imx/imx-atf.git;protocol=https"
 SRC_URI = "${ATF_SRC};branch=${SRCBRANCH} \
 "
 SRCREV = "ba76d337e9564ea97b5024640b6dcca9bd054ffb"

--- a/meta-bsp/recipes-bsp/imx-mkimage/imx-mkimage_git.inc
+++ b/meta-bsp/recipes-bsp/imx-mkimage/imx-mkimage_git.inc
@@ -3,7 +3,7 @@
 DEPENDS = "zlib-native openssl-native"
 
 SRCBRANCH = "lf-5.10.y_1.0.0"
-IMX_MKIMAGE_SRC ?= "git://source.codeaurora.org/external/imx/imx-mkimage.git;protocol=https"
+IMX_MKIMAGE_SRC ?= "git://github.com/nxp-imx/imx-mkimage.git;protocol=https"
 SRC_URI = "${IMX_MKIMAGE_SRC};branch=${SRCBRANCH}"
 SRCREV = "66fa5777341fd116a5616bd85491621f2e1c74bf"
 S = "${WORKDIR}/git"

--- a/meta-bsp/recipes-bsp/imx-test/imx-test_git.bbappend
+++ b/meta-bsp/recipes-bsp/imx-test/imx-test_git.bbappend
@@ -5,7 +5,7 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 
 SRCBRANCH = "lf-5.10.y_1.0.0"
-IMXTEST_SRC ?= "git://source.codeaurora.org/external/imx/imx-test.git;protocol=https"
+IMXTEST_SRC ?= "git://github.com/nxp-imx/imx-test.git;protocol=https"
 SRC_URI = " \
     ${IMXTEST_SRC};branch=${SRCBRANCH} \
     file://memtool_profile \

--- a/meta-bsp/recipes-connectivity/nxp-wlan-sdk/nxp-wlan-sdk_git.inc
+++ b/meta-bsp/recipes-connectivity/nxp-wlan-sdk/nxp-wlan-sdk_git.inc
@@ -3,7 +3,7 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://gpl-2.0.txt;md5=ab04ac0f249af12befccb94447c08b77"
 
 SRCBRANCH = "lf-5.10.y_1.0.0"
-MRVL_SRC ?= "git://source.codeaurora.org/external/imx/mwifiex.git;protocol=https"
+MRVL_SRC ?= "git://github.com/nxp-imx/mwifiex.git;protocol=https"
 SRC_URI = "${MRVL_SRC};branch=${SRCBRANCH}"
 SRCREV = "a15984e718f21088e5bd057e838792546591e19a"
 

--- a/meta-bsp/recipes-graphics/imx-gpu-apitrace/imx-gpu-apitrace_9.0.0.bb
+++ b/meta-bsp/recipes-graphics/imx-gpu-apitrace/imx-gpu-apitrace_9.0.0.bb
@@ -4,7 +4,7 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=aeb969185a143c3c25130bc2c3ef9a50"
 DEPENDS = "imx-gpu-viv zlib libpng procps"
 
-APITRACE_SRC ?= "git://source.codeaurora.org/external/imx/apitrace-imx.git;protocol=https"
+APITRACE_SRC ?= "git://github.com/nxp-imx/apitrace-imx.git;protocol=https"
 SRCBRANCH = "imx_9.0"
 SRC_URI = "${APITRACE_SRC};branch=${SRCBRANCH}"
 SRCREV = "c50e6a954e44998f2e3793a8de863e961f8008c6"

--- a/meta-bsp/recipes-graphics/wayland/wayland-protocols_1.20.imx.bb
+++ b/meta-bsp/recipes-graphics/wayland/wayland-protocols_1.20.imx.bb
@@ -9,7 +9,7 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://COPYING;md5=c7b12b6702da38ca028ace54aae3d484 \
                     file://stable/presentation-time/presentation-time.xml;endline=26;md5=4646cd7d9edc9fa55db941f2d3a7dc53"
 
-WAYLAND_PROTOCOLS_SRC ?= "git://source.codeaurora.org/external/imx/wayland-protocols-imx.git;protocol=https"
+WAYLAND_PROTOCOLS_SRC ?= "git://github.com/nxp-imx/wayland-protocols-imx.git;protocol=https"
 SRCBRANCH = "wayland-protocols-imx-1.20"
 SRC_URI = "${WAYLAND_PROTOCOLS_SRC};branch=${SRCBRANCH} "
 SRCREV = "9cacf108d0ee5863c7a656da5d2271bc2396e43d" 

--- a/meta-bsp/recipes-graphics/wayland/weston_9.0.0.imx.bb
+++ b/meta-bsp/recipes-graphics/wayland/weston_9.0.0.imx.bb
@@ -2,7 +2,7 @@ require recipes-graphics/wayland/weston_9.0.0.bb
 
 SRC_URI_remove = "https://wayland.freedesktop.org/releases/${BPN}-${PV}.tar.xz \
                   file://0001-tests-include-fcntl.h-for-open-O_RDWR-O_CLOEXEC-and-.patch"
-WESTON_SRC ?= "git://source.codeaurora.org/external/imx/weston-imx.git;protocol=https"
+WESTON_SRC ?= "git://github.com/nxp-imx/weston-imx.git;protocol=https"
 SRC_URI_prepend = "${WESTON_SRC};branch=weston-imx-9.0 "
 SRCREV = "230e9bc3d647e511e0601e3d45034f22495ed3c7"
 S = "${WORKDIR}/git"

--- a/meta-bsp/recipes-graphics/xorg-driver/xf86-video-imx-vivante_6.4.0.p0.0.bb
+++ b/meta-bsp/recipes-graphics/xorg-driver/xf86-video-imx-vivante_6.4.0.p0.0.bb
@@ -1,6 +1,6 @@
 require recipes-graphics/xorg-driver/xf86-video-imx-vivante_6.4.0.p0.0.bb
 
-XF86_VIDEO_IMX_VIVANTE_SRC ?= "git://source.codeaurora.org/external/imx/xf86-video-imx-vivante.git;protocol=https"
+XF86_VIDEO_IMX_VIVANTE_SRC ?= "git://github.com/nxp-imx/xf86-video-imx-vivante.git;protocol=https"
 SRC_URI = " \
     ${XF86_VIDEO_IMX_VIVANTE_SRC};branch=${SRCBRANCH} \
     file://rc.autohdmi \

--- a/meta-bsp/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.3.p1.2.bb
+++ b/meta-bsp/recipes-kernel/kernel-modules/kernel-module-imx-gpu-viv_6.4.3.p1.2.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/GPL-2.0;md5=801f80980d171dd6425
 
 SRCBRANCH = "lf-5.10.y"
 LOCALVERSION = "-1.0.0"
-KERNEL_SRC ?= "git://source.codeaurora.org/external/imx/linux-imx.git;protocol=https"
+KERNEL_SRC ?= "git://github.com/nxp-imx/linux-imx.git;protocol=https"
 SRC_URI = " \
     ${KERNEL_SRC};branch=${SRCBRANCH};subpath=drivers/mxc/gpu-viv;destsuffix=git/src \
     file://Add-makefile.patch \

--- a/meta-bsp/recipes-kernel/kernel-modules/kernel-module-isp-vvcam_4.2.2.6.1.bb
+++ b/meta-bsp/recipes-kernel/kernel-modules/kernel-module-isp-vvcam_4.2.2.6.1.bb
@@ -5,7 +5,7 @@ LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://${WORKDIR}/git/vvcam/LICENSE;md5=64381a6ea83b48c39fe524c85f65fb44"
 
 SRCBRANCH = "imx_5.10_1.0.0"
-ISP_KERNEL_SRC ?= "git://source.codeaurora.org/external/imx/isp-vvcam.git;protocol=https"
+ISP_KERNEL_SRC ?= "git://github.com/nxp-imx/isp-vvcam.git;protocol=https"
 
 SRC_URI = " \
     ${ISP_KERNEL_SRC};branch=${SRCBRANCH} \

--- a/meta-bsp/recipes-kernel/kernel-modules/kernel-module-qcacld-lea.inc
+++ b/meta-bsp/recipes-kernel/kernel-modules/kernel-module-qcacld-lea.inc
@@ -2,7 +2,7 @@ SUMMARY = "Qualcomm WiFi driver for QCA module 9377 and 6174"
 LICENSE = "BSD & GPLv2"
 LIC_FILES_CHKSUM = "file://CORE/HDD/src/wlan_hdd_main.c;beginline=1;endline=20;md5=ec8d62116b13db773825ebf7cf91be1d;"
 
-QCACLD_SRC ?= "git://source.codeaurora.org/external/imx/qcacld-2.0-imx.git;protocol=https"
+QCACLD_SRC ?= "git://github.com/nxp-imx/qcacld-2.0-imx.git;protocol=https"
 
 SRC_URI = "${QCACLD_SRC};branch=IMX_CNSS.LEA.NRT_3.0"
 SRCREV = "7dc91e5977f31d60741c55682564788c0f930163"

--- a/meta-bsp/recipes-kernel/kernel-modules/kernel-module-qcacld_3.1.inc
+++ b/meta-bsp/recipes-kernel/kernel-modules/kernel-module-qcacld_3.1.inc
@@ -3,7 +3,7 @@ LICENSE = "BSD & GPLv2"
 LIC_FILES_CHKSUM = "file://CORE/HDD/src/wlan_hdd_main.c;beginline=1;endline=20;md5=ec8d62116b13db773825ebf7cf91be1d;"
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/kernel-module-qca:"
-QCACLD_SRC ?= "git://source.codeaurora.org/external/imx/qcacld-2.0-imx.git;protocol=https"
+QCACLD_SRC ?= "git://github.com/nxp-imx/qcacld-2.0-imx.git;protocol=https"
 
 #Kernel 5.4
 SRC_URI = "${QCACLD_SRC};branch=IMX_CNSS.LEA.NRT_3.0_KRL5.4"

--- a/meta-bsp/recipes-kernel/linux/linux-imx-headers_5.10.bb
+++ b/meta-bsp/recipes-kernel/linux/linux-imx-headers_5.10.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 SRCBRANCH = "lf-5.10.y"
 LOCALVERSION = "-1.0.0"
-KERNEL_SRC ?= "git://source.codeaurora.org/external/imx/linux-imx.git;protocol=https"
+KERNEL_SRC ?= "git://github.com/nxp-imx/linux-imx.git;protocol=https"
 SRC_URI = "${KERNEL_SRC};branch=${SRCBRANCH}"
 
 SRCREV = "32513c25d8c7867f07b44900368346795357b48e"

--- a/meta-bsp/recipes-multimedia/alsa/imx-alsa-plugins_git.bb
+++ b/meta-bsp/recipes-multimedia/alsa/imx-alsa-plugins_git.bb
@@ -17,7 +17,7 @@ LIC_FILES_CHKSUM = "file://COPYING.GPL;md5=94d55d512a9ba36caa9b7df079bae19f"
 
 inherit autotools pkgconfig use-imx-headers
 
-IMXALSA_SRC ?= "git://source.codeaurora.org/external/imx/imx-alsa-plugins.git;protocol=https"
+IMXALSA_SRC ?= "git://github.com/nxp-imx/imx-alsa-plugins.git;protocol=https"
 SRCBRANCH = "MM_04.06.00_2012_L5.10.y"
 
 SRC_URI = "${IMXALSA_SRC};branch=${SRCBRANCH}"

--- a/meta-bsp/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.18.0.imx.bb
+++ b/meta-bsp/recipes-multimedia/gstreamer/gstreamer1.0-plugins-bad_1.18.0.imx.bb
@@ -10,7 +10,7 @@ DEFAULT_PREFERENCE = "-1"
 PACKAGE_ARCH_imxpxp = "${MACHINE_SOCARCH}"
 PACKAGE_ARCH_mx8 = "${MACHINE_SOCARCH}"
 
-GST1.0-PLUGINS-BAD_SRC ?= "gitsm://source.codeaurora.org/external/imx/gst-plugins-bad.git;protocol=https"
+GST1.0-PLUGINS-BAD_SRC ?= "gitsm://github.com/nxp-imx/gst-plugins-bad.git;protocol=https"
 SRCBRANCH = "MM_04.06.00_2012_L5.10.y"
 
 SRC_URI = " \

--- a/meta-bsp/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.18.0.imx.bb
+++ b/meta-bsp/recipes-multimedia/gstreamer/gstreamer1.0-plugins-base_1.18.0.imx.bb
@@ -4,7 +4,7 @@ LICENSE = "GPLv2+ & LGPLv2+"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6762ed442b3822387a51c92d928ead0d \
 "
 
-GST1.0-PLUGINS-BASE_SRC ?= "gitsm://source.codeaurora.org/external/imx/gst-plugins-base.git;protocol=https"
+GST1.0-PLUGINS-BASE_SRC ?= "gitsm://github.com/nxp-imx/gst-plugins-base.git;protocol=https"
 SRCBRANCH = "MM_04.06.00_2012_L5.10.y"
 SRCREV = "c0198efbc99f38f5b7620dba6915fd666fd53bea"
 SRC_URI = "${GST1.0-PLUGINS-BASE_SRC};branch=${SRCBRANCH} \

--- a/meta-bsp/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.18.0.imx.bb
+++ b/meta-bsp/recipes-multimedia/gstreamer/gstreamer1.0-plugins-good_1.18.0.imx.bb
@@ -1,7 +1,7 @@
 require recipes-multimedia/gstreamer/gstreamer1.0-plugins-common.inc
 
 
-GST1.0-PLUGINS-GOOD_SRC ?= "gitsm://source.codeaurora.org/external/imx/gst-plugins-good.git;protocol=https"
+GST1.0-PLUGINS-GOOD_SRC ?= "gitsm://github.com/nxp-imx/gst-plugins-good.git;protocol=https"
 SRCBRANCH = "MM_04.06.00_2012_L5.10.y"
 
 SRC_URI = " \

--- a/meta-bsp/recipes-multimedia/gstreamer/gstreamer1.0_1.18.0.imx.bb
+++ b/meta-bsp/recipes-multimedia/gstreamer/gstreamer1.0_1.18.0.imx.bb
@@ -14,7 +14,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6762ed442b3822387a51c92d928ead0d \
                     file://gst/gst.h;beginline=1;endline=21;md5=e059138481205ee2c6fc1c079c016d0d"
 
 # Use i.MX fork of GST for customizations
-GST1.0_SRC ?= "gitsm://source.codeaurora.org/external/imx/gstreamer.git;protocol=https"
+GST1.0_SRC ?= "gitsm://github.com/nxp-imx/gstreamer.git;protocol=https"
 SRCBRANCH = "MM_04.06.00_2012_L5.10.y"
 
 SRC_URI = " \

--- a/meta-bsp/recipes-multimedia/gstreamer/imx-gst1.0-plugin_4.6.0.bb
+++ b/meta-bsp/recipes-multimedia/gstreamer/imx-gst1.0-plugin_4.6.0.bb
@@ -20,7 +20,7 @@ RCONFLICTS_${PN} = "gst1.0-fsl-plugin"
 LIC_FILES_CHKSUM = "file://COPYING-LGPL-2;md5=5f30f0716dfdd0d91eb439ebec522ec2 \
                     file://COPYING-LGPL-2.1;md5=fbc093901857fcd118f065f900982c24"
 
-IMXGST_SRC ?= "git://source.codeaurora.org/external/imx/imx-gst1.0-plugin.git;protocol=https"
+IMXGST_SRC ?= "git://github.com/nxp-imx/imx-gst1.0-plugin.git;protocol=https"
 SRCBRANCH = "MM_04.06.00_2012_L5.10.y"
 
 SRC_URI = "${IMXGST_SRC};branch=${SRCBRANCH} \

--- a/meta-bsp/recipes-security/optee-imx/optee-client_3.10.0.imx.bb
+++ b/meta-bsp/recipes-security/optee-imx/optee-client_3.10.0.imx.bb
@@ -3,7 +3,7 @@ require optee-client.imx.inc
 
 FILESEXTRAPATHS_prepend := "${THISDIR}/optee-client:"
 
-OPTEE_CLIENT_SRC ?= "git://source.codeaurora.org/external/imx/imx-optee-client.git;protocol=https"
+OPTEE_CLIENT_SRC ?= "git://github.com/nxp-imx/imx-optee-client.git;protocol=https"
 SRC_URI = "${OPTEE_CLIENT_SRC};branch=${SRCBRANCH} \
            file://tee-supplicant.service"
 SRCBRANCH = "lf-5.10.y_1.0.0"

--- a/meta-bsp/recipes-security/optee-imx/optee-os_3.10.0.imx.bb
+++ b/meta-bsp/recipes-security/optee-imx/optee-os_3.10.0.imx.bb
@@ -3,7 +3,7 @@ require optee-os.imx.inc
 
 DEPENDS_append = " python3-pycryptodomex-native"
 
-OPTEE_OS_SRC ?= "git://source.codeaurora.org/external/imx/imx-optee-os.git;protocol=https"
+OPTEE_OS_SRC ?= "git://github.com/nxp-imx/imx-optee-os.git;protocol=https"
 SRC_URI = "${OPTEE_OS_SRC};branch=${SRCBRANCH}"
 
 SRCBRANCH = "lf-5.10.y_1.0.0"

--- a/meta-bsp/recipes-security/optee-imx/optee-test_3.10.0.imx.bb
+++ b/meta-bsp/recipes-security/optee-imx/optee-test_3.10.0.imx.bb
@@ -3,7 +3,7 @@ require optee-test.imx.inc
 
 DEPENDS_append = " python3-pycryptodomex-native"
 
-OPTEE_TEST_SRC ?= "git://source.codeaurora.org/external/imx/imx-optee-test.git;protocol=https"
+OPTEE_TEST_SRC ?= "git://github.com/nxp-imx/imx-optee-test.git;protocol=https"
 SRC_URI = "${OPTEE_TEST_SRC};branch=${SRCBRANCH}"
 
 SRCBRANCH = "lf-5.10.y_1.0.0"

--- a/meta-bsp/recipes-security/smw/keyctl-caam_git.bb
+++ b/meta-bsp/recipes-security/smw/keyctl-caam_git.bb
@@ -7,7 +7,7 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://COPYING;md5=8636bd68fc00cc6a3809b7b58b45f982"
 
 SRCBRANCH = "lf-5.10.y_1.0.0"
-KEYCTL_CAAM_SRC ?= "git://source.codeaurora.org/external/imx/keyctl_caam.git;protocol=https"
+KEYCTL_CAAM_SRC ?= "git://github.com/nxp-imx/keyctl_caam.git;protocol=https"
 SRC_URI = "${KEYCTL_CAAM_SRC};branch=${SRCBRANCH}"
 
 SRCREV = "6b80882e3d5bc986a1f2f9512845170658ba9ea2"

--- a/meta-bsp/recipes-security/smw/smw_git.bb
+++ b/meta-bsp/recipes-security/smw/smw_git.bb
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=8636bd68fc00cc6a3809b7b58b45f982"
 DEPENDS = "imx-seco-libs json-c optee-os optee-client python3-pycryptodomex-native"
 
 SRCBRANCH = "lf-5.10.y_1.0.0"
-SMW_LIB_SRC ?= "git://source.codeaurora.org/external/imx/imx-smw.git;protocol=https"
+SMW_LIB_SRC ?= "git://github.com/nxp-imx/imx-smw.git;protocol=https"
 SRC_URI = "${SMW_LIB_SRC};branch=${SRCBRANCH}"
 SRCREV = "0b8de728a9bf34fc3cf6a49e8b64d05ccdc326b1"
 

--- a/meta-bsp/recipes-support/opencv/opencv_4.4.0.imx.bb
+++ b/meta-bsp/recipes-support/opencv/opencv_4.4.0.imx.bb
@@ -13,7 +13,7 @@ SRC_URI_remove = " \
     git://github.com/opencv/opencv.git;name=opencv \
     file://0002-Make-opencv-ts-create-share-library-intead-of-static.patch \
 "
-OPENCV_SRC ?= "git://source.codeaurora.org/external/imx/opencv-imx.git;protocol=https"
+OPENCV_SRC ?= "git://github.com/nxp-imx/opencv-imx.git;protocol=https"
 SRCBRANCH = "4.4.0_imx"
 SRC_URI =+ "${OPENCV_SRC};branch=${SRCBRANCH};name=opencv"
 SRC_URI += " \

--- a/meta-bsp/recipes-utils/simg2img/simg2img_git.bb
+++ b/meta-bsp/recipes-utils/simg2img/simg2img_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=b433a746dd6fe8862028b1d7fc412a4d"
 
 DEPENDS = "zlib"
 
-SIMG2IMG_SRC ?= "git://source.codeaurora.org/external/imx/simg2img.git;protocol=https"
+SIMG2IMG_SRC ?= "git://github.com/nxp-imx/simg2img.git;protocol=https"
 SRC_BRANCH = "master"
 
 SRC_URI = "${SIMG2IMG_SRC};branch=${SRC_BRANCH}"

--- a/meta-ml/recipes-libraries/arm-compute-library/arm-compute-library_git-imx.bb
+++ b/meta-ml/recipes-libraries/arm-compute-library/arm-compute-library_git-imx.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=a700d9de43fc22e998001a63c3feb1d2 \
 
 PV = "20.08.imx+git${SRCPV}"
 SRCBRANCH = "lf-5.10.y_1.0.0"
-ARM_COMPUTELIBRARY_SRC ?= "git://source.codeaurora.org/external/imx/arm-computelibrary-imx.git;protocol=https"
+ARM_COMPUTELIBRARY_SRC ?= "git://github.com/nxp-imx/arm-computelibrary-imx.git;protocol=https"
 SRC_URI = "${ARM_COMPUTELIBRARY_SRC};branch=${SRCBRANCH}"
 SRCREV = "203f466760aa584913ff11d744078f817d9efee5" 
 

--- a/meta-ml/recipes-libraries/armnn/armnn_20.08.bb
+++ b/meta-ml/recipes-libraries/armnn/armnn_20.08.bb
@@ -3,7 +3,7 @@ DESCRIPTION = "Linux software and tools to enable machine learning (Caffe/Tensor
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3e14a924c16f7d828b8335a59da64074"
 
-ARMNN_SRC ?= "git://source.codeaurora.org/external/imx/armnn-imx.git;protocol=https"
+ARMNN_SRC ?= "git://github.com/nxp-imx/armnn-imx.git;protocol=https"
 SRCBRANCH = "lf-5.10.y_1.0.0"
 
 SRCREV = "a9de15b5faed05dfa8f94030060bac1e0df0f21d" 

--- a/meta-ml/recipes-libraries/nn-imx/nn-imx_1.1.9.bb
+++ b/meta-ml/recipes-libraries/nn-imx/nn-imx_1.1.9.bb
@@ -4,7 +4,7 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=bba6cdb9c2b03c849ed4975ed9ed90dc"
 
 DEPENDS = "imx-gpu-viv"
-NN-IMX_SRC ?= "git://source.codeaurora.org/external/imx/nn-imx.git;protocol=https"
+NN-IMX_SRC ?= "git://github.com/nxp-imx/nn-imx.git;protocol=https"
 SRCBRANCH = "imx_1.1.9"
 
 SRCREV = "15dd34c68dadde5af77665558669d7dc1ffc45f1"

--- a/meta-ml/recipes-libraries/onnxruntime/onnxruntime_1.5.3.bb
+++ b/meta-ml/recipes-libraries/onnxruntime/onnxruntime_1.5.3.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=980784f0a7f667becbed133924b263bf"
 
 DEPENDS = "libpng zlib ${BPN}-native"
 
-ONNXRUNTIME_SRC ?= "git://source.codeaurora.org/external/imx/onnxruntime-imx.git;protocol=https"
+ONNXRUNTIME_SRC ?= "git://github.com/nxp-imx/onnxruntime-imx.git;protocol=https"
 SRCBRANCH = "lf-5.10.y_1.0.0"
 
 SRCREV = "e9ddc224126e678723260adb7eb10ad89dd6ea68"

--- a/meta-ml/recipes-libraries/tensorflow-lite/tensorflow-lite_2.4.0.bb
+++ b/meta-ml/recipes-libraries/tensorflow-lite/tensorflow-lite_2.4.0.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=64a34301f8e355f57ec992c2af3e5157"
 
 DEPENDS = "zlib unzip-native python3 python3-numpy-native python3-pip-native python3-wheel-native python3-pybind11-native"
 
-TENSORFLOW_LITE_SRC ?= "git://source.codeaurora.org/external/imx/tensorflow-imx.git;protocol=https"
+TENSORFLOW_LITE_SRC ?= "git://github.com/nxp-imx/tensorflow-imx.git;protocol=https"
 SRCBRANCH = "lf-5.10.y_1.0.0"
 
 SRC_URI = "${TENSORFLOW_LITE_SRC};branch=${SRCBRANCH}"

--- a/meta-sdk/dynamic-layers/qt5-layer/recipes-qt/qt5/gstreamer1.0-plugins-good-qt_1.18.0.imx.bb
+++ b/meta-sdk/dynamic-layers/qt5-layer/recipes-qt/qt5/gstreamer1.0-plugins-good-qt_1.18.0.imx.bb
@@ -1,6 +1,6 @@
 require recipes-multimedia/gstreamer/gstreamer1.0-plugins-common.inc
 
-GST1.0-PLUGINS-GOOD_SRC ?= "gitsm://source.codeaurora.org/external/imx/gst-plugins-good.git;protocol=https"
+GST1.0-PLUGINS-GOOD_SRC ?= "gitsm://github.com/nxp-imx/gst-plugins-good.git;protocol=https"
 SRCBRANCH = "MM_04.06.00_2012_L5.10.y"
 
 SRC_URI = " \

--- a/meta-sdk/recipes-extended/jailhouse/jailhouse_0.12.bb
+++ b/meta-sdk/recipes-extended/jailhouse/jailhouse_0.12.bb
@@ -14,7 +14,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=9fa7f895f96bde2d47fd5b7d95b6ba4d \
 "
 
 SRCBRANCH = "lf-5.10.y_v0.12"
-IMX_JAILHOUSE_SRC ?= "git://source.codeaurora.org/external/imx/imx-jailhouse.git;protocol=ssh"
+IMX_JAILHOUSE_SRC ?= "git://github.com/nxp-imx/imx-jailhouse.git;protocol=ssh"
 
 SRC_URI = "${IMX_JAILHOUSE_SRC};branch=${SRCBRANCH} \
            file://0001-tools-scripts-update-shebang-to-python3.patch \

--- a/meta-sdk/recipes-extended/xen/imx-xen_4.13.0.bb
+++ b/meta-sdk/recipes-extended/xen/imx-xen_4.13.0.bb
@@ -3,7 +3,7 @@ require xen.inc
 require xen-hypervisor.inc
 
 SRCBRANCH = "lf-5.10.y_4.13"
-XEN_SRC ?= "git://source.codeaurora.org/external/imx/imx-xen.git;protocol=https"
+XEN_SRC ?= "git://github.com/nxp-imx/imx-xen.git;protocol=https"
 
 LIC_FILES_CHKSUM ?= "file://COPYING;md5=4295d895d4b5ce9d070263d52f030e49"
 

--- a/meta-sdk/recipes-graphics/libgpuperfcnt/gputop_6.4.3.p1.2.bb
+++ b/meta-sdk/recipes-graphics/libgpuperfcnt/gputop_6.4.3.p1.2.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE.txt;md5=bcacc6777a7173f8b95b5d1e0ac341ae"
 
 DEPENDS = "libgpuperfcnt"
 
-GPUTOP_SRC ?= "git://source.codeaurora.org/external/imx/imx-gputop.git;protocol=https"
+GPUTOP_SRC ?= "git://github.com/nxp-imx/imx-gputop.git;protocol=https"
 SRCBRANCH = "release"
 SRC_URI = "${GPUTOP_SRC};branch=${SRCBRANCH} "
 SRCREV = "ac3bdd424adeade26105ad8e75e4abacc1125488" 

--- a/meta-sdk/recipes-graphics/vk-gl-cts/opengl-es-cts.inc
+++ b/meta-sdk/recipes-graphics/vk-gl-cts/opengl-es-cts.inc
@@ -9,7 +9,7 @@ LICENSE = "Apache-2.0"
 
 DEPENDS = "libpng zlib"
 
-VKGLCTS_SRC ?= "git://source.codeaurora.org/external/imx/vk-gl-cts-imx.git;protocol=https"
+VKGLCTS_SRC ?= "git://github.com/nxp-imx/vk-gl-cts-imx.git;protocol=https"
 SRC_URI = "${VKGLCTS_SRC};name=vk-gl-cts;branch=imx-${BP}"
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
NXP repositories have migrated from 'codeaurora' to Girhub and so some URIs should be updated.